### PR TITLE
docs: correct typo in npx mcp command

### DIFF
--- a/node/mem0/README.md
+++ b/node/mem0/README.md
@@ -16,13 +16,13 @@ A Model Context Protocol (MCP) server that provides memory storage and retrieval
 ### Running with npx
 
 ```bash
-env MEM0_API_KEY=your-api-key-here npx -y @mem0/mcp
+env MEM0_API_KEY=your-api-key-here npx -y @mem0/mcp-server
 ```
 
 ### Manual Installation
 
 ```bash
-npm install -g @mem0/mcp
+npm install -g @mem0/mcp-server
 ```
 
 ## Configuration for AI Tools
@@ -39,7 +39,7 @@ To configure Mem0 MCP in Cursor:
 4. Enter the following:
    - Name: "mem0-mcp" (or your preferred name)
    - Type: "command"
-   - Command: `env MEM0_API_KEY=your-api-key-here npx -y @mem0/mcp`
+   - Command: `env MEM0_API_KEY=your-api-key-here npx -y @mem0/mcp-server`
 
 To configure Mem0 MCP using JSON configuration:
 
@@ -48,7 +48,7 @@ To configure Mem0 MCP using JSON configuration:
   "mcpServers": {
     "mem0-mcp": {
       "command": "npx",
-      "args": ["-y", "@mem0/mcp"],
+      "args": ["-y", "@mem0/mcp-server"],
       "env": {
         "MEM0_API_KEY": "YOUR-API-KEY-HERE"
       }
@@ -75,7 +75,7 @@ Add the following JSON block to your User Settings (JSON) file in VS Code:
     "servers": {
       "mem0-memory": {
         "command": "npx",
-        "args": ["-y", "@mem0/mcp"],
+        "args": ["-y", "@mem0/mcp-server"],
         "env": {
           "MEM0_API_KEY": "${input:apiKey}"
         }

--- a/node/mem0/package.json
+++ b/node/mem0/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "mem0-mcp": "dist/index.js"
+    "mem0-mcp-server": "dist/index.js"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## 🔧 Fix Incorrect Command Reference in Documentation
This PR updates the documentation and package.json to consistently reference the correct binary name: mem0-mcp-server instead of mem0-mcp.

### 📄 Changes Made:
Updated all CLI command examples in README.md from @mem0/mcp to @mem0/mcp-server.

Corrected the bin field in package.json to match the actual command: mem0-mcp-server.

### ✅ Why
The previously documented command (mem0-mcp) does not match the actual binary being installed and executed (mem0-mcp-server). This caused confusion when attempting to run the MCP server as described.

