### PR TITLE
Replace limit with top_k in SearchMemoriesArgs

### DIFF
--- a/src/mem0_mcp_server/schemas.py
+++ b/src/mem0_mcp_server/schemas.py
@@ -52,7 +52,7 @@ class SearchMemoriesArgs(BaseModel):
     filters: Optional[Dict[str, Any]] = Field(
         None, description="Additional filter clauses; user_id is injected automatically."
     )
-    limit: Optional[int] = Field(None, description="Optional maximum number of matches.")
+    top_k: Optional[int] = Field(None, description="The number of top results to return (default: 10).")
     enable_graph: Optional[bool] = Field(
         None, description="Set True only when the user asks for graph knowledge."
     )

--- a/src/mem0_mcp_server/server.py
+++ b/src/mem0_mcp_server/server.py
@@ -262,8 +262,8 @@ def create_server() -> FastMCP:
             Optional[Dict[str, Any]],
             Field(default=None, description="Additional filter clauses (user_id injected automatically)."),
         ] = None,
-        limit: Annotated[
-            Optional[int], Field(default=None, description="Maximum number of results to return.")
+        top_k: Annotated[
+            Optional[int], Field(default=None, description="Number of top results to return (default: 10).")
         ] = None,
         enable_graph: Annotated[
             Optional[bool],
@@ -280,7 +280,7 @@ def create_server() -> FastMCP:
         args = SearchMemoriesArgs(
             query=query,
             filters=filters,
-            limit=limit,
+            top_k=top_k,
             enable_graph=_default_enable_graph(enable_graph, graph_default),
         )
         payload = args.model_dump(exclude_none=True)


### PR DESCRIPTION
The [Search Memories API](https://docs.mem0.ai/api-reference/memory/search-memories) lists a `top_k` parameter, but the MCP is using `limit`.

I have replaced `limit` with `top_k`.