### PR TITLE
Add timestamp parameter to AddMemoryArgs

### DIFF
--- a/src/mem0_mcp_server/schemas.py
+++ b/src/mem0_mcp_server/schemas.py
@@ -37,6 +37,7 @@ class AddMemoryArgs(BaseModel):
         ),
     )
     user_id: Optional[str] = Field(None, description="Override for the Mem0 user ID.")
+    timestamp: Optional[int] = Field(None, description="Optional timestamp of the memory, in Unix format.")
     agent_id: Optional[str] = Field(None, description="Optional agent identifier.")
     app_id: Optional[str] = Field(None, description="Optional app identifier.")
     run_id: Optional[str] = Field(None, description="Optional run identifier.")

--- a/src/mem0_mcp_server/server.py
+++ b/src/mem0_mcp_server/server.py
@@ -187,6 +187,10 @@ def create_server() -> FastMCP:
             Optional[str],
             Field(default=None, description="Override the default user scope for this write."),
         ] = None,
+        timestamp: Annotated[
+            Optional[int],
+            Field(default=None, description="Optional memory timestamp."),
+        ] = None,
         agent_id: Annotated[
             Optional[str], Field(default=None, description="Optional agent identifier.")
         ] = None,
@@ -216,6 +220,7 @@ def create_server() -> FastMCP:
             text=text,
             messages=[ToolMessage(**msg) for msg in messages] if messages else None,
             user_id=user_id if user_id else (default_user if not (agent_id or run_id) else None),
+            timestamp=timestamp,
             agent_id=agent_id,
             app_id=app_id,
             run_id=run_id,


### PR DESCRIPTION
This PR add the `timestamp` parameter listed in the [add memories API](https://docs.mem0.ai/api-reference/memory/add-memories#body-timestamp-one-of-0).
This is needed in order to support the [memory timestamps](https://docs.mem0.ai/platform/features/timestamp) in the MCP.