### PR TITLE
Deprecate repo in favor of cloud-hosted Mem0 MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Mem0 MCP Server
-
-> **This repository has been archived.** Mem0 now offers an official cloud-hosted MCP server that replaces this package. Please use the cloud version instead.
+> [!CAUTION]
+> ## This project has been archived
 >
-> **Docs:** [https://docs.mem0.ai/platform/mem0-mcp](https://docs.mem0.ai/platform/mem0-mcp)
+> **mem0-mcp-server** is no longer actively maintained and this repository is now a public archive.
+>
+> **Looking for Mem0 MCP?** We now offer an official cloud-hosted MCP server. Check out the [docs](https://docs.mem0.ai/platform/mem0-mcp) to get started.
 >
 > **Quick install across all major clients:**
 > ```bash
@@ -12,8 +13,10 @@
 >   --url "https://mcp.mem0.ai/mcp" \
 >   --clients "claude,claude code,cursor,windsurf,vscode,opencode"
 > ```
+>
+> You're welcome to fork this repo and build on it — the Apache 2.0 license still applies.
 
----
+# Mem0 MCP Server
 
 [![PyPI version](https://img.shields.io/pypi/v/mem0-mcp-server.svg)](https://pypi.org/project/mem0-mcp-server/) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![smithery badge](https://smithery.ai/badge/@mem0ai/mem0-memory-mcp)](https://smithery.ai/server/@mem0ai/mem0-memory-mcp)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 >
 > **mem0-mcp-server** is no longer actively maintained and this repository is now a public archive.
 >
+> Thank you to the 640+ stargazers, 140+ forkers, and every contributor who helped shape this project. Your support and feedback meant the world to us.
+>
 > **Looking for Mem0 MCP?** We now offer an official cloud-hosted MCP server. Check out the [docs](https://docs.mem0.ai/platform/mem0-mcp) to get started.
 >
 > **Quick install across all major clients:**
@@ -13,8 +15,6 @@
 >   --url "https://mcp.mem0.ai/mcp" \
 >   --clients "claude,claude code,cursor,windsurf,vscode,opencode"
 > ```
->
-> You're welcome to fork this repo and build on it — the Apache 2.0 license still applies.
 
 # Mem0 MCP Server
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Mem0 MCP Server
 
+> **This repository has been deprecated.** Mem0 now offers an official cloud-hosted MCP server that replaces this package. Please use the cloud version instead.
+>
+> **Docs:** [https://docs.mem0.ai/platform/mem0-mcp](https://docs.mem0.ai/platform/mem0-mcp)
+>
+> **Quick install across all major clients:**
+> ```bash
+> npx mcp-add \
+>   --name mem0-mcp \
+>   --type http \
+>   --url "https://mcp.mem0.ai/mcp" \
+>   --clients "claude,claude code,cursor,windsurf,vscode,opencode"
+> ```
+>
+> This repo will be archived shortly. No further updates will be made here.
+
+---
+
 [![PyPI version](https://img.shields.io/pypi/v/mem0-mcp-server.svg)](https://pypi.org/project/mem0-mcp-server/) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![smithery badge](https://smithery.ai/badge/@mem0ai/mem0-memory-mcp)](https://smithery.ai/server/@mem0ai/mem0-memory-mcp)
 
 `mem0-mcp-server` wraps the official [Mem0](https://mem0.ai) Memory API as a Model Context Protocol (MCP) server so any MCP-compatible client (Claude Desktop, Cursor, custom agents) can add, search, update, and delete long-term memories.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mem0 MCP Server
 
-> **This repository has been deprecated.** Mem0 now offers an official cloud-hosted MCP server that replaces this package. Please use the cloud version instead.
+> **This repository has been archived.** Mem0 now offers an official cloud-hosted MCP server that replaces this package. Please use the cloud version instead.
 >
 > **Docs:** [https://docs.mem0.ai/platform/mem0-mcp](https://docs.mem0.ai/platform/mem0-mcp)
 >
@@ -12,8 +12,6 @@
 >   --url "https://mcp.mem0.ai/mcp" \
 >   --clients "claude,claude code,cursor,windsurf,vscode,opencode"
 > ```
->
-> This repo will be archived shortly. No further updates will be made here.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a deprecation notice at the top of the README
- Points users to the official cloud-hosted MCP server docs: https://docs.mem0.ai/platform/mem0-mcp
- Includes `npx mcp-add` one-liner for quick setup across Claude, Cursor, Windsurf, VS Code, and OpenCode

## Next steps

After merging, archive the repository on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)